### PR TITLE
Distro features

### DIFF
--- a/kas/chromium/ozone-wayland.yml
+++ b/kas/chromium/ozone-wayland.yml
@@ -5,3 +5,6 @@ local_conf_header:
   chromium-ozone-wayland: |
     PREFERRED_PROVIDER_chromium = "chromium-ozone-wayland"
     PACKAGECONFIG:append:pn-chromium-ozone-wayland = " proprietary-codecs"
+    # Enable Wayland as a distribution feature
+    DISTRO_FEATURES:append = " wayland"
+    IMAGE_FEATURES:append = " splash package-management ssh-server-dropbear hwcodecs weston"

--- a/kas/chromium/x11.yml
+++ b/kas/chromium/x11.yml
@@ -5,3 +5,6 @@ local_conf_header:
   chromium-x11: |
     PREFERRED_PROVIDER_chromium = "chromium-x11"
     PACKAGECONFIG:append:pn-chromium-x11 = " proprietary-codecs"
+    # Ensure X11 is enabled as a distribution feature
+    DISTRO_FEATURES:append = " x11"
+    IMAGE_FEATURES:append = " splash package-management x11-base"

--- a/recipes-core/images/chromium-test-image.bb
+++ b/recipes-core/images/chromium-test-image.bb
@@ -1,21 +1,11 @@
-require recipes-sato/images/core-image-sato.bb
+# Use core-image-minimal as base and build up from there
+inherit core-image
 
 # Install the preferred Chromium provider (set via KAS configuration)
 IMAGE_INSTALL += "${PREFERRED_PROVIDER_chromium} chromium-tests"
 
 SUMMARY = "Test image for Chromium browser builds"
 DESCRIPTION = "This image contains the configured Chromium variant for testing purposes."
-
-# Add common packages for testing
-IMAGE_INSTALL += " \
-    packagegroup-core-x11-sato \
-    packagegroup-core-x11-xserver \
-    xorg-minimal-fonts \
-    liberation-fonts \
-    ttf-dejavu-sans \
-    ttf-dejavu-sans-mono \
-    ttf-dejavu-serif \
-"
 
 # Development and debugging tools
 IMAGE_INSTALL += " \

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -63,6 +63,7 @@ kas build ./meta-chromium-test/kas/$kas_file_name-test.yml || exit 1
 # Copy the built image to test images directory
 if [ -d ./build/tmp/deploy/images/$qemu_machine ]; then
   echo "Copying built image to /yocto/test-images/$kas_file_name"
+  rm -rf /yocto/test-images/$kas_file_name
   cp -r ./build/tmp/deploy/images/$qemu_machine /yocto/test-images/$kas_file_name
   echo "Successfully created test image: $kas_file_name"
   ls -la /yocto/test-images/$kas_file_name


### PR DESCRIPTION
Compilation was working ok. We were compiling the wayland and x11 versions of Chromium, but we were installing them on core-image-sato. Wayland version of the Chromium was unable to run.

I've specified the distro features correctly and added windowing system components as IMAGE_FEATURES. Now I can run the browsers inside the qemu images.